### PR TITLE
Pre-determining the current breakpoint on configuration

### DIFF
--- a/response.js
+++ b/response.js
@@ -747,17 +747,21 @@
           , lazy: null
           , i: 0                      // integer   the index of the current highest active breakpoint min
           , uid: null
-              
-          , reset: function() {// Reset / fire crossover events:
-          
-                var subjects = this.breakpoints
+
+          , _decideValue: function() {
+              var subjects = this.breakpoints
                   , i = subjects.length
                   , tempIndex = 0;
-                
-                // This is similar to the decideValue loop
-                while( !tempIndex && i-- ) {
-                    this.fn(subjects[i]) && (tempIndex = i);
-                }
+
+              // This is similar to the decideValue loop
+              while( !tempIndex && i-- ) {
+                  this.fn(subjects[i]) && (tempIndex = i);
+              }
+
+              return tempIndex;
+          }
+          , reset: function() {// Reset / fire crossover events:
+                var tempIndex = this._decideValue();
 
                 // Fire the crossover event if crossover has occured:
                 if (tempIndex !== this.i) {
@@ -841,7 +845,9 @@
                 }
 
                 sets.all = sets.all.concat(sets[this.uid] = this.keys); // combined keys ===> sets.all
-                
+
+                this.i = this._decideValue();
+
                 return this; // chainable
             }
 


### PR DESCRIPTION
Hi Ryan, in my current project I'm binding quite a lot of logic to the crossover-event and realized, that after the page being loaded, the crossover-event is being fired when resizing the window for some px (but not actually crossing a breakpoint). The problem resides in the `Elemset.reset()` method

``` js
// tempIndex is the index of the breakpoint
// while this.i === 0 initially
if (tempIndex !== this.i) { /* ... */ }
```

So I added some logic to determine `this.i` initially inside the configure-method. Maybe I'm doing something wrong here and this is rubbish, but please check my changes. Cheers, Alex
