### PR TITLE
0.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Response
 Response is an experimental [jQuery](http://jquery.com)/[Ender](https://github.com/ender-js/Ender)/[Zepto](http://zeptojs.com) plugin that gives web designers tools for building responsive websites. It can dynamically swap content based on [breakpoints](#breakpoint-sets) and data attributes. (<b>npm</b>: [response.js](https://www.npmjs.org/package/response.js))
 
-## API [(0.9)](../../releases)
+## API [(0.10)](../../releases)
 ### Breakpoint sets
 
 Response's main feature is its breakpoint sets. They offer the ability to serve different content via breakpoint-based data attributes. They are best applied with a mobile-first approach. Devs can choose custom breakpoints to create exactly data attributes they need. By default none are setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "response.js",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "response.js",
   "description": "Responsive design toolkit",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "license": "CC0-1.0",
   "author": "Ryan Van Etten",
   "main": "response.js",


### PR DESCRIPTION
Release: [v0.10.0](https://github.com/ryanve/response.js/releases/tag/v0.10.0)

Bumped via [`npm version`](https://docs.npmjs.com/cli/version) which include the v in the tag. I plan use this going forward.

Changeset: https://github.com/ryanve/response.js/compare/0.9.1...v0.10.0